### PR TITLE
Remove extra `/` from delete_offline_collectors url

### DIFF
--- a/sumo_mgmt.py
+++ b/sumo_mgmt.py
@@ -683,7 +683,7 @@ def update_source(collector_list):
 
 
 def delete_offline_collectors():
-    url = args.url[0] + '/collectors/offline'
+    url = args.url[0] + 'collectors/offline'
     r = requests.delete(url, params={'aliveBeforeDays': args.deleteOfflineCollectors[0]}, auth=(args.accessid[0], args.accesskey[0]))
 
     if r.status_code != 200 and r.status_code != 201:


### PR DESCRIPTION
In it's current form the API returns a 400 for the `-deleteOfflineCollectors` action. Removing the leading forward slash matches all the other urls in this script.